### PR TITLE
Update Python publish workflow to use GitHub releases and OIDC auth

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,8 @@
 name: Publish Python Package
 
 on:
-  push:
-    branches:
-      - main
   release:
-    types: [created]
+    types: [created, published]
 
 jobs:
   build:
@@ -33,7 +30,9 @@ jobs:
   publish-pypi:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
+    permissions:
+      id-token: write
+    if: github.event_name == 'release'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -43,9 +42,30 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install uv
-    - name: Build and publish
-      env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        pip install build uv
+    - name: Extract version from tag
+      id: get_version
       run: |
-        bash scripts/publish.sh
+        VERSION=${GITHUB_REF#refs/tags/}
+        # Remove 'v' prefix if present
+        VERSION=${VERSION#v}
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "Using version $VERSION from release tag"
+    - name: Update version in files
+      run: |
+        # Update pyproject.toml
+        sed -i "s/version = \"[0-9]*\.[0-9]*\.[0-9]*\"/version = \"$VERSION\"/" pyproject.toml
+        # Update version file if it exists
+        if [ -f "src/mix_python_sdk/_version.py" ]; then
+          sed -i "s/__version__: str = \"[0-9]*\.[0-9]*\.[0-9]*\"/__version__: str = \"$VERSION\"/" src/mix_python_sdk/_version.py
+          sed -i "s/__user_agent__: str = \"speakeasy-sdk\/python [0-9]*\.[0-9]*\.[0-9]* /__user_agent__: str = \"speakeasy-sdk\/python $VERSION /" src/mix_python_sdk/_version.py
+        fi
+    - name: Build package
+      run: |
+        python -m pip install --upgrade build
+        python -m build
+        
+    - name: Publish package using OIDC
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true


### PR DESCRIPTION
- Changed workflow to trigger only on GitHub releases
- Added version extraction from release tag
- Updated automated version file changes
- Implemented PyPI's OpenID Connect (OIDC) authentication
- Added skip-existing flag to avoid duplicate version errors

🤖 Generated with [Claude Code](https://claude.ai/code)