### PR TITLE
Update workflow to trigger only on published releases

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,7 +2,7 @@ name: Publish Python Package
 
 on:
   release:
-    types: [created, published]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
- Changed trigger from both 'created' and 'published' to just 'published'
- This prevents duplicate workflow runs when creating a release

🤖 Generated with [Claude Code](https://claude.ai/code)